### PR TITLE
Remove _ensure_posix

### DIFF
--- a/friendly_data/dpkg.py
+++ b/friendly_data/dpkg.py
@@ -23,21 +23,6 @@ import friendly_data.registry as registry
 logger = getLogger(__name__)
 
 
-def _ensure_posix(pkg):
-    """Ensure resource paths in the package are POSIX compliant
-
-    FIXME: The :class:`datapackage.Package` implementation does not ensure
-    paths are POSIX paths on Windows, correct them after the fact.  This is a
-    temporary solution; see:
-    https://github.com/frictionlessdata/datapackage-py/issues/279
-
-    """
-    if is_windows():
-        to_posix = Spec(Invoke(posixpathstr).specs("path"))
-        glom(pkg, ("resources", Iter().map(Assign("path", to_posix)).all()))
-    return pkg
-
-
 def fullpath(resource: Resource) -> Path:
     """Get full path of a resource
 

--- a/friendly_data/dpkg.py
+++ b/friendly_data/dpkg.py
@@ -152,7 +152,7 @@ def create_pkg(
         _res = resource_(spec, basepath=basepath, infer=infer)
         pkg.add_resource(_res)
 
-    return _ensure_posix(pkg)
+    return pkg
 
 
 def read_pkg(pkg_path: _path_t, extract_dir: Optional[_path_t] = None):
@@ -210,7 +210,7 @@ def read_pkg(pkg_path: _path_t, extract_dir: Optional[_path_t] = None):
         logger.error(msg)
         raise FileNotFoundError(msg)
 
-    return _ensure_posix(pkg)
+    return pkg
 
 
 class pkgindex(List[Dict]):


### PR DESCRIPTION
_ensure_posix causes `dpkg.read_pkg()` to fail on datapackages with inline data.
Based on https://github.com/frictionlessdata/frictionless-py/issues/590, the issue for which _ensure_posix was introduced in the first place appears to be fixed.